### PR TITLE
Refactor Total Medals to Remove N+1 Query

### DIFF
--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -3,8 +3,4 @@ class Olympian < ActiveRecord::Base
   belongs_to :sport
   has_many :olympian_events
   has_many :events, through: :olympian_events
-
-  def total_medals
-    OlympianEvent.where(olympian_id: self.id).where.not(medal: 0).count
-  end
 end

--- a/app/serializers/olympian_serializer.rb
+++ b/app/serializers/olympian_serializer.rb
@@ -11,6 +11,6 @@ class OlympianSerializer
   end
 
   attribute :total_medals do |obj|
-    obj.total_medals
+    obj.olympian_events.inject(0) {|sum,x| sum + (x.medal == 0 ? 0 : 1)}
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -8,9 +8,4 @@ RSpec.describe Olympian, type: :model do
   it 'seed data is present' do
     expect(Olympian.count).to eq(2850)
   end
-
-  it 'total_medals' do
-    denis = Olympian.find(50)
-    expect(denis.total_medals).to eq(3)
-  end
 end


### PR DESCRIPTION
Closes #9 

While it does replace a SQL query with a ruby enumerable, the enumerable is only 1 query, whilst the object method was an N+1, so it's drastically faster.